### PR TITLE
Allow "clear" only env configuration

### DIFF
--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -18,7 +18,7 @@ module Mrsk::Utils
     if (secrets = env["secret"]).present?
       argumentize("-e", secrets.to_h { |key| [ key, ENV.fetch(key) ] }, redacted: true) + argumentize("-e", env["clear"])
     else
-      argumentize "-e", env
+      argumentize "-e", env.fetch("clear", env)
     end
   end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -105,6 +105,14 @@ class ConfigurationTest < ActiveSupport::TestCase
     ENV["PASSWORD"] = nil
   end
 
+  test "env args with only clear" do
+    config = Mrsk::Configuration.new(@deploy.tap { |c| c.merge!({
+      env: { "clear" => { "PORT" => "3000" } }
+    }) })
+
+    assert_equal [ "-e", "PORT=3000" ], config.env_args
+  end
+
   test "env args with only secrets" do
     ENV["PASSWORD"] = "secret123"
     config = Mrsk::Configuration.new(@deploy.tap { |c| c.merge!({


### PR DESCRIPTION
Currently a configuration that has an explicit `clear` key but no `secret` will quietly pass the ENV variables exactly as they are defined under `env:`.

```yaml
env:
  clear:
    NON_SECRET_ENV: "value"
```

```shell
… -e "{ "clear" => { "NON_SECRET_ENV" => "value" } }"
```

This changes here ensure that with `clear` only env configs the `clear` key is simply ignored.