### PR TITLE
Allow customizing traefik args

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ volumes:
   - "/local/path:/container/path"
 ```
 
+### Customizing traefik
+
+You can customize the traefik command line using `traefik`:
+
+```yaml
+traefik:
+  - --accesslog=true
+  - --accesslog.format=json
+  - --metrics.prometheus=true
+  - --metrics.prometheus.buckets=0.1,0.3,1.2,5.0
+```
+
 ### Using different roles for servers
 
 If your application uses separate hosts for running jobs or other roles beyond the default web running, you can specify these hosts in a dedicated role with a new entrypoint command like so:

--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -9,7 +9,8 @@ class Mrsk::Commands::Traefik < Mrsk::Commands::Base
       "-v /var/run/docker.sock:/var/run/docker.sock",
       "traefik",
       "--providers.docker",
-      "--log.level=DEBUG"
+      "--log.level=DEBUG",
+      *config.traefik_args
   end
 
   def start

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -72,6 +72,12 @@ class Mrsk::Configuration
     roles.select(&:running_traefik?).flat_map(&:hosts)
   end
 
+  def traefik_args
+    if raw_config.traefik.present?
+      raw_config.traefik
+    end
+  end
+
 
   def version
     @version
@@ -137,6 +143,7 @@ class Mrsk::Configuration
       service_with_version: service_with_version,
       env_args: env_args,
       volume_args: volume_args,
+      traefik_args: traefik_args,
       ssh_options: ssh_options,
       builder: raw_config.builder,
       accessories: raw_config.accessories

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -10,7 +10,8 @@ class ConfigurationTest < ActiveSupport::TestCase
       registry: { "username" => "dhh", "password" => "secret" },
       env: { "REDIS_URL" => "redis://x/y" },
       servers: [ "1.1.1.1", "1.1.1.2" ],
-      volumes: ["/local/path:/container/path"]
+      volumes: ["/local/path:/container/path"],
+      traefik: ["--accesslog=true", "--accesslog.format=json", "--metrics.prometheus=true"]
     }
 
     @config = Mrsk::Configuration.new(@deploy)
@@ -157,6 +158,10 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal ["--volume", "/local/path:/container/path"], @config.volume_args
   end
 
+  test "traefik_args" do
+    assert_equal ["--accesslog=true", "--accesslog.format=json", "--metrics.prometheus=true"], @config.traefik_args
+  end
+
   test "erb evaluation of yml config" do
     config = Mrsk::Configuration.create_from Pathname.new(File.expand_path("fixtures/deploy.erb.yml", __dir__))
     assert_equal "my-user", config.registry["username"]
@@ -181,6 +186,6 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "to_h" do
-    assert_equal({ :roles=>["web"], :hosts=>["1.1.1.1", "1.1.1.2"], :primary_host=>"1.1.1.1", :version=>"missing", :repository=>"dhh/app", :absolute_image=>"dhh/app:missing", :service_with_version=>"app-missing", :env_args=>["-e", "REDIS_URL=redis://x/y"], :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]}, :volume_args=>["--volume", "/local/path:/container/path"] }, @config.to_h)
+    assert_equal({ :roles=>["web"], :hosts=>["1.1.1.1", "1.1.1.2"], :primary_host=>"1.1.1.1", :version=>"missing", :repository=>"dhh/app", :absolute_image=>"dhh/app:missing", :service_with_version=>"app-missing", :env_args=>["-e", "REDIS_URL=redis://x/y"], :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]}, :volume_args=>["--volume", "/local/path:/container/path"], :traefik_args=>["--accesslog=true", "--accesslog.format=json", "--metrics.prometheus=true"] }, @config.to_h)
   end
 end


### PR DESCRIPTION
Defaults aside, we want to configure specific options for traefik. This PR is a very crude passthru for command line arguments to traefik. 

```yaml
traefik:
  - --accesslog=true
  - --accesslog.format=json
  - --metrics.prometheus=true

# Generates
# --accesslog=true --accesslog.format=json --metrics.prometheus=true
```

Ultimately, we might want to restrict which ones we can pass via some more intelligent parsing of options like so:

```yaml
traefik:
  accesslog:
    format:json
  metrics:
    prometheus: true

# Would generate
# --accesslog=true --accesslog.format=json --metrics.prometheus=true
```
