### PR TITLE
Align config class name with file name

### DIFF
--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -52,7 +52,7 @@ class Mrsk::Configuration
   end
 
   def accessories
-    @accessories ||= raw_config.accessories&.keys&.collect { |name| Mrsk::Configuration::Assessory.new(name, config: self) } || []
+    @accessories ||= raw_config.accessories&.keys&.collect { |name| Mrsk::Configuration::Accessory.new(name, config: self) } || []
   end
 
   def accessory(name)

--- a/lib/mrsk/configuration/accessory.rb
+++ b/lib/mrsk/configuration/accessory.rb
@@ -1,4 +1,4 @@
-class Mrsk::Configuration::Assessory
+class Mrsk::Configuration::Accessory
   delegate :argumentize, :argumentize_env_with_secrets, to: Mrsk::Utils
 
   attr_accessor :name, :specifics


### PR DESCRIPTION
`Mrsk::Configuration::Assessory` -> `Mrsk::Configuration::Accessory` thus aligning with the name of the file.