### PR TITLE
Change version terminology to tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ badb1aa51db4   registry.digitalocean.com/user/app:6ef8a6a84c525b123c5245345a8483
 6f170d1172ae   registry.digitalocean.com/user/app:e5d9d7c2b898289dfbc5f7f1334140d984eedae4   "/rails/bin/docker-e…"   31 minutes ago   Exited (1) 27 minutes ago              chat-e5d9d7c2b898289dfbc5f7f1334140d984eedae4
 ```
 
-From the example above, we can see that `e5d9d7c2b898289dfbc5f7f1334140d984eedae4` was the last version, so it's available as a rollback target. We can perform this rollback by running `mrsk rollback e5d9d7c2b898289dfbc5f7f1334140d984eedae4`. That'll stop `6ef8a6a84c525b123c5245345a8483f86d05a123` and then start `e5d9d7c2b898289dfbc5f7f1334140d984eedae4`. Because the old container is still available, this is very quick. Nothing to download from the registry.
+From the example above, we can see that `e5d9d7c2b898289dfbc5f7f1334140d984eedae4` was the previous image tag, so it's available as a rollback target. We can perform this rollback by running `mrsk rollback e5d9d7c2b898289dfbc5f7f1334140d984eedae4`. That'll stop `6ef8a6a84c525b123c5245345a8483f86d05a123` and then start `e5d9d7c2b898289dfbc5f7f1334140d984eedae4`. Because the old container is still available, this is very quick. Nothing to download from the registry.
 
 Note that by default old containers are pruned after 3 days when you run `mrsk deploy`.
 

--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -9,7 +9,7 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
           execute *MRSK.app.run(role: role.name)
         rescue SSHKit::Command::Failed => e
           if e.message =~ /already in use/
-            error "Container with same version already deployed on #{host}, starting that instead"
+            error "Container with same tag already deployed on #{host}, starting that instead"
             execute *MRSK.app.start, host: host
           else
             raise
@@ -19,11 +19,11 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
     end
   end
   
-  desc "start", "Start existing app on servers (use --version=<git-hash> to designate specific version)"
-  option :version, desc: "Defaults to the most recent git-hash in local repository"
+  desc "start", "Start existing app on servers (use --tag=<git-hash> to designate specific tag)"
+  option :tag, desc: "Defaults to the most recent git-hash in local repository"
   def start
-    if (version = options[:version]).present?
-      on(MRSK.hosts) { execute *MRSK.app.start(version: version) }
+    if (tag = options[:tag]).present?
+      on(MRSK.hosts) { execute *MRSK.app.start(tag: tag) }
     else
       on(MRSK.hosts) { execute *MRSK.app.start, raise_on_non_zero_exit: false }
     end

--- a/lib/mrsk/cli/base.rb
+++ b/lib/mrsk/cli/base.rb
@@ -10,7 +10,7 @@ module Mrsk::Cli
     class_option :verbose, type: :boolean, aliases: "-v", desc: "Detailed logging"
     class_option :quiet, type: :boolean, aliases: "-q", desc: "Minimal logging"
 
-    class_option :version, desc: "Run commands against a specific app version"
+    class_option :tag, aliases: "-t", desc: "Run commands against a specific app tag"
 
     class_option :primary, type: :boolean, aliases: "-p", desc: "Run commands only on primary host instead of all"
     class_option :hosts, aliases: "-h", desc: "Run commands on these hosts instead of all (separate by comma)"
@@ -29,7 +29,7 @@ module Mrsk::Cli
         MRSK.tap do |commander|
           commander.config_file = Pathname.new(File.expand_path(options[:config_file]))
           commander.destination = options[:destination]
-          commander.version     = options[:version]
+          commander.tag         = options[:tag]
 
           commander.specific_hosts    = options[:hosts]&.split(",")
           commander.specific_roles    = options[:roles]&.split(",")

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -31,7 +31,7 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
     end
   end
 
-  desc "redeploy", "Deploy new version of the app to servers (without bootstrapping servers, starting Traefik, pruning, and registry login)"
+  desc "redeploy", "Deploy new tag of the app to servers (without bootstrapping servers, starting Traefik, pruning, and registry login)"
   def redeploy
     print_runtime do
       invoke "mrsk:cli:build:deliver"
@@ -40,11 +40,11 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
     end
   end
 
-  desc "rollback [VERSION]", "Rollback the app to VERSION (that must already be on servers)"
-  def rollback(version)
+  desc "rollback [TAG]", "Rollback the app to TAG (that must already be on servers)"
+  def rollback(tag)
     on(MRSK.hosts) do
       execute *MRSK.app.stop, raise_on_non_zero_exit: false
-      execute *MRSK.app.start(version: version)
+      execute *MRSK.app.start(tag: tag)
     end
   end
 

--- a/lib/mrsk/commander.rb
+++ b/lib/mrsk/commander.rb
@@ -9,7 +9,7 @@ require "mrsk/commands/traefik"
 require "mrsk/commands/registry"
 
 class Mrsk::Commander
-  attr_accessor :config_file, :destination, :verbosity, :version
+  attr_accessor :config_file, :destination, :verbosity, :tag
 
   def initialize(config_file: nil, destination: nil, verbosity: :info)
     @config_file, @destination, @verbosity = config_file, destination, verbosity
@@ -18,7 +18,7 @@ class Mrsk::Commander
   def config
     @config ||= \
       Mrsk::Configuration
-        .create_from(config_file, destination: destination, version: cascading_version)
+        .create_from(config_file, destination: destination, tag: cascading_tag)
         .tap { |config| configure_sshkit_with(config) }
   end
 
@@ -87,8 +87,8 @@ class Mrsk::Commander
   end
 
   private
-    def cascading_version
-      version.presence || ENV["VERSION"] || `git rev-parse HEAD`.strip
+    def cascading_tag
+      tag.presence || ENV["tag"] || `git rev-parse HEAD`.strip
     end
 
     # Lazy setup of SSHKit

--- a/lib/mrsk/commands/app.rb
+++ b/lib/mrsk/commands/app.rb
@@ -7,7 +7,7 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
     docker :run,
       "-d",
       "--restart unless-stopped",
-      "--name", config.service_with_version,
+      "--name", config.service_with_tag,
       *rails_master_key_arg,
       *role.env_args,
       *config.volume_args,
@@ -16,8 +16,8 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
       role.cmd
   end
 
-  def start(version: config.version)
-    docker :start, "#{config.service}-#{version}"
+  def start(tag: config.tag)
+    docker :start, "#{config.service}-#{tag}"
   end
 
   def current_container_id
@@ -42,7 +42,7 @@ class Mrsk::Commands::App < Mrsk::Commands::Base
   def exec(*command, interactive: false)
     docker :exec,
       ("-it" if interactive),
-      config.service_with_version,
+      config.service_with_tag,
       *command
   end
 

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -12,13 +12,13 @@ class Mrsk::Configuration
   attr_accessor :raw_config
 
   class << self
-    def create_from(base_config_file, destination: nil, version: "missing")
+    def create_from(base_config_file, destination: nil, tag: "missing")
       new(load_config_file(base_config_file).tap do |config|
         if destination
           config.deep_merge! \
             load_config_file destination_config_file(base_config_file, destination)
         end
-      end, version: version)
+      end, tag: tag)
     end
 
     private
@@ -36,9 +36,9 @@ class Mrsk::Configuration
       end
   end
 
-  def initialize(raw_config, version: "missing", validate: true)
+  def initialize(raw_config, tag: "missing", validate: true)
     @raw_config = ActiveSupport::InheritableOptions.new(raw_config)
-    @version = version
+    @tag = tag
     valid? if validate
   end
 
@@ -73,8 +73,8 @@ class Mrsk::Configuration
   end
 
 
-  def version
-    @version
+  def tag
+    @tag
   end
 
   def repository
@@ -82,11 +82,11 @@ class Mrsk::Configuration
   end
 
   def absolute_image
-    "#{repository}:#{version}"
+    "#{repository}:#{tag}"
   end
 
-  def service_with_version
-    "#{service}-#{version}"
+  def service_with_tag
+    "#{service}-#{tag}"
   end
 
 
@@ -131,10 +131,10 @@ class Mrsk::Configuration
       roles: role_names,
       hosts: all_hosts,
       primary_host: primary_web_host,
-      version: version,
+      tag: tag,
       repository: repository,
       absolute_image: absolute_image,
-      service_with_version: service_with_version,
+      service_with_tag: service_with_tag,
       env_args: env_args,
       volume_args: volume_args,
       ssh_options: ssh_options,

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -58,6 +58,6 @@ class CommandsBuilderTest < ActiveSupport::TestCase
 
   private
     def new_builder_command(additional_config = {})
-      Mrsk::Commands::Builder.new(Mrsk::Configuration.new(@config.merge(additional_config), version: "123"))
+      Mrsk::Commands::Builder.new(Mrsk::Configuration.new(@config.merge(additional_config), tag: "123"))
     end
 end

--- a/test/commands/traefik_test.rb
+++ b/test/commands/traefik_test.rb
@@ -73,6 +73,6 @@ class CommandsTraefikTest < ActiveSupport::TestCase
 
   private
     def new_command
-      Mrsk::Commands::Traefik.new(Mrsk::Configuration.new(@config, version: "123"))
+      Mrsk::Commands::Traefik.new(Mrsk::Configuration.new(@config, tag: "123"))
     end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -66,9 +66,9 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal [ "1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4" ], config.traefik_hosts
   end
 
-  test "version" do
-    assert_equal "missing", @config.version
-    assert_equal "123", Mrsk::Configuration.new(@deploy, version: "123").version
+  test "tag" do
+    assert_equal "missing", @config.tag
+    assert_equal "123", Mrsk::Configuration.new(@deploy, tag: "123").tag
   end
 
   test "repository" do
@@ -85,8 +85,8 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "ghcr.io/dhh/app:missing", config.absolute_image
   end
 
-  test "service with version" do
-    assert_equal "app-missing", @config.service_with_version
+  test "service with tag" do
+    assert_equal "app-missing", @config.service_with_tag
   end
 
   test "env args" do
@@ -181,6 +181,6 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "to_h" do
-    assert_equal({ :roles=>["web"], :hosts=>["1.1.1.1", "1.1.1.2"], :primary_host=>"1.1.1.1", :version=>"missing", :repository=>"dhh/app", :absolute_image=>"dhh/app:missing", :service_with_version=>"app-missing", :env_args=>["-e", "REDIS_URL=redis://x/y"], :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]}, :volume_args=>["--volume", "/local/path:/container/path"] }, @config.to_h)
+    assert_equal({ :roles=>["web"], :hosts=>["1.1.1.1", "1.1.1.2"], :primary_host=>"1.1.1.1", :tag=>"missing", :repository=>"dhh/app", :absolute_image=>"dhh/app:missing", :service_with_tag=>"app-missing", :env_args=>["-e", "REDIS_URL=redis://x/y"], :ssh_options=>{:user=>"root", :auth_methods=>["publickey"]}, :volume_args=>["--volume", "/local/path:/container/path"] }, @config.to_h)
   end
 end


### PR DESCRIPTION
The rollback feature (and other things) are based on the respective image's
tag. While the tag can represent the app's version, we're still targeting an
image's tag and not an image version. This aligns with upstream terminology and
can help understand what's actually being targeted from an operating perspective.

https://github.com/rails/mrsk/issues/32