### PR TITLE
Add zeitwerk to check file names match classes

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,10 +3,23 @@ require "active_support/test_case"
 require "active_support/testing/autorun"
 require "debug"
 require "sshkit"
+require "zeitwerk"
 
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["VERBOSE"]
 
 SSHKit.config.backend = SSHKit::Backend::Printer
 
 class ActiveSupport::TestCase
+  test "Zeitwerk compliance" do 
+    loader = Zeitwerk::Loader.for_gem
+    loader.setup
+
+    begin
+      loader.eager_load(force: true)
+    rescue Zeitwerk::NameError => e
+      flunk e.message
+    else
+      assert true
+    end
+  end
 end


### PR DESCRIPTION
In https://github.com/rails/mrsk/pull/31 class names had to be updated as they didn't match the file name.

To prevent this from happening again we should do a sanity check in CI with Zeitwerk.  The Zeitwerk loader will error if classes are not named as per the filename.

I'm not sure if we should be explicit in requiring Zeitwerk as a dependency?  Zeitwerk is a transitive dependency of`railties` which is included in MRSK already.  