### PR TITLE
Load with Zeitwerk

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       dotenv (~> 2.8)
       sshkit (~> 1.21)
       thor (~> 1.2)
+      zeitwerk (~> 2.5)
 
 GEM
   remote: https://rubygems.org/
@@ -91,6 +92,7 @@ PLATFORMS
   arm64-darwin-22
   x86_64-darwin-20
   x86_64-darwin-21
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/bin/mrsk
+++ b/bin/mrsk
@@ -4,7 +4,7 @@
 Thread.report_on_exception = false
 
 require "dotenv/load"
-require "mrsk/cli"
+require "mrsk"
 
 begin
   Mrsk::Cli::Main.start(ARGV)

--- a/lib/mrsk.rb
+++ b/lib/mrsk.rb
@@ -1,5 +1,9 @@
 module Mrsk
 end
 
-require "mrsk/version"
-require "mrsk/commander"
+require "zeitwerk"
+
+loader = Zeitwerk::Loader.for_gem
+loader.ignore("#{__dir__}/mrsk/sshkit_with_ext.rb")
+loader.setup
+loader.eager_load # We need all commands loaded.

--- a/lib/mrsk/cli.rb
+++ b/lib/mrsk/cli.rb
@@ -1,9 +1,5 @@
-require "mrsk"
-
 module Mrsk::Cli
 end
 
 # SSHKit uses instance eval, so we need a global const for ergonomics
 MRSK = Mrsk::Commander.new
-
-require "mrsk/cli/main"

--- a/lib/mrsk/cli/accessory.rb
+++ b/lib/mrsk/cli/accessory.rb
@@ -1,5 +1,3 @@
-require "mrsk/cli/base"
-
 class Mrsk::Cli::Accessory < Mrsk::Cli::Base
   desc "boot [NAME]", "Boot accessory service on host (use NAME=all to boot all accessories)"
   def boot(name)

--- a/lib/mrsk/cli/app.rb
+++ b/lib/mrsk/cli/app.rb
@@ -1,5 +1,3 @@
-require "mrsk/cli/base"
-
 class Mrsk::Cli::App < Mrsk::Cli::Base
   desc "boot", "Boot app on servers (or reboot app if already running)"
   def boot
@@ -40,7 +38,7 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
       execute *MRSK.app.start, raise_on_non_zero_exit: false
     end
   end
-  
+
   desc "stop", "Stop app on servers"
   def stop
     on(MRSK.hosts) do
@@ -48,12 +46,12 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
       execute *MRSK.app.stop, raise_on_non_zero_exit: false
     end
   end
-  
+
   desc "details", "Display details about app containers"
   def details
     on(MRSK.hosts) { |host| puts_by_host host, capture_with_info(*MRSK.app.info) }
   end
-  
+
   desc "exec [CMD]", "Execute a custom command on servers"
   option :interactive, aliases: "-i", type: :boolean, default: false, desc: "Execute command over ssh for an interactive shell (use for console/bash)"
   option :reuse, type: :boolean, default: false, desc: "Reuse currently running container instead of starting a new one"
@@ -110,7 +108,7 @@ class Mrsk::Cli::App < Mrsk::Cli::Base
   def current
     on(MRSK.hosts) { |host| puts_by_host host, capture_with_info(*MRSK.app.current_container_id) }
   end
-  
+
   desc "logs", "Show lines from app on servers"
   option :since, aliases: "-s", desc: "Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)"
   option :lines, type: :numeric, aliases: "-n", desc: "Number of log lines to pull from each server"

--- a/lib/mrsk/cli/build.rb
+++ b/lib/mrsk/cli/build.rb
@@ -1,5 +1,3 @@
-require "mrsk/cli/base"
-
 class Mrsk::Cli::Build < Mrsk::Cli::Base
   desc "deliver", "Deliver a newly built app image to servers"
   def deliver
@@ -11,7 +9,7 @@ class Mrsk::Cli::Build < Mrsk::Cli::Base
   def push
     cli = self
 
-    run_locally do 
+    run_locally do
       begin
         MRSK.with_verbosity(:debug) { execute *MRSK.builder.push }
       rescue SSHKit::Command::Failed => e

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -1,13 +1,3 @@
-require "mrsk/cli/base"
-
-require "mrsk/cli/accessory"
-require "mrsk/cli/app"
-require "mrsk/cli/build"
-require "mrsk/cli/prune"
-require "mrsk/cli/registry"
-require "mrsk/cli/server"
-require "mrsk/cli/traefik"
-
 class Mrsk::Cli::Main < Mrsk::Cli::Base
   desc "setup", "Setup all accessories and deploy the app to servers"
   def setup

--- a/lib/mrsk/cli/prune.rb
+++ b/lib/mrsk/cli/prune.rb
@@ -1,5 +1,3 @@
-require "mrsk/cli/base"
-
 class Mrsk::Cli::Prune < Mrsk::Cli::Base
   desc "all", "Prune unused images and stopped containers"
   def all

--- a/lib/mrsk/cli/registry.rb
+++ b/lib/mrsk/cli/registry.rb
@@ -1,5 +1,3 @@
-require "mrsk/cli/base"
-
 class Mrsk::Cli::Registry < Mrsk::Cli::Base
   desc "login", "Login to the registry locally and remotely"
   def login

--- a/lib/mrsk/cli/server.rb
+++ b/lib/mrsk/cli/server.rb
@@ -1,5 +1,3 @@
-require "mrsk/cli/base"
-
 class Mrsk::Cli::Server < Mrsk::Cli::Base
   desc "bootstrap", "Ensure Docker is installed on the servers"
   def bootstrap

--- a/lib/mrsk/cli/traefik.rb
+++ b/lib/mrsk/cli/traefik.rb
@@ -1,5 +1,3 @@
-require "mrsk/cli/base"
-
 class Mrsk::Cli::Traefik < Mrsk::Cli::Base
   desc "boot", "Boot Traefik on servers"
   def boot

--- a/lib/mrsk/commander.rb
+++ b/lib/mrsk/commander.rb
@@ -1,14 +1,5 @@
 require "active_support/core_ext/enumerable"
 
-require "mrsk/configuration"
-require "mrsk/commands/accessory"
-require "mrsk/commands/app"
-require "mrsk/commands/auditor"
-require "mrsk/commands/builder"
-require "mrsk/commands/prune"
-require "mrsk/commands/traefik"
-require "mrsk/commands/registry"
-
 class Mrsk::Commander
   attr_accessor :config_file, :destination, :verbosity, :version
 
@@ -83,7 +74,7 @@ class Mrsk::Commander
   end
 
 
-  def with_verbosity(level) 
+  def with_verbosity(level)
     old_level = SSHKit.config.output_verbosity
     SSHKit.config.output_verbosity = level
     yield

--- a/lib/mrsk/commands/accessory.rb
+++ b/lib/mrsk/commands/accessory.rb
@@ -1,5 +1,3 @@
-require "mrsk/commands/base"
-
 class Mrsk::Commands::Accessory < Mrsk::Commands::Base
   attr_reader :accessory_config
   delegate :service_name, :image, :host, :port, :files, :directories, :env_args, :volume_args, :label_args, to: :accessory_config
@@ -10,7 +8,7 @@ class Mrsk::Commands::Accessory < Mrsk::Commands::Base
   end
 
   def run
-    docker :run, 
+    docker :run,
       "--name", service_name,
       "-d",
       "--restart", "unless-stopped",

--- a/lib/mrsk/commands/app.rb
+++ b/lib/mrsk/commands/app.rb
@@ -1,5 +1,3 @@
-require "mrsk/commands/base"
-
 class Mrsk::Commands::App < Mrsk::Commands::Base
   def run(role: :web)
     role = config.role(role)

--- a/lib/mrsk/commands/auditor.rb
+++ b/lib/mrsk/commands/auditor.rb
@@ -1,5 +1,4 @@
 require "active_support/core_ext/time/conversions"
-require "mrsk/commands/base"
 
 class Mrsk::Commands::Auditor < Mrsk::Commands::Base
   def record(line)

--- a/lib/mrsk/commands/builder.rb
+++ b/lib/mrsk/commands/builder.rb
@@ -1,5 +1,3 @@
-require "mrsk/commands/base"
-
 class Mrsk::Commands::Builder < Mrsk::Commands::Base
   delegate :create, :remove, :push, :pull, :info, to: :target
 
@@ -36,8 +34,3 @@ class Mrsk::Commands::Builder < Mrsk::Commands::Base
     @multiarch_remote ||= Mrsk::Commands::Builder::Multiarch::Remote.new(config)
   end
 end
-
-require "mrsk/commands/builder/native"
-require "mrsk/commands/builder/native/remote"
-require "mrsk/commands/builder/multiarch"
-require "mrsk/commands/builder/multiarch/remote"

--- a/lib/mrsk/commands/builder/base.rb
+++ b/lib/mrsk/commands/builder/base.rb
@@ -1,5 +1,3 @@
-require "mrsk/commands/base"
-
 class Mrsk::Commands::Builder::Base < Mrsk::Commands::Base
   delegate :argumentize, to: Mrsk::Utils
 

--- a/lib/mrsk/commands/builder/multiarch.rb
+++ b/lib/mrsk/commands/builder/multiarch.rb
@@ -1,5 +1,3 @@
-require "mrsk/commands/builder/base"
-
 class Mrsk::Commands::Builder::Multiarch < Mrsk::Commands::Builder::Base
   def create
     docker :buildx, :create, "--use", "--name", builder_name

--- a/lib/mrsk/commands/builder/multiarch/remote.rb
+++ b/lib/mrsk/commands/builder/multiarch/remote.rb
@@ -1,5 +1,3 @@
-require "mrsk/commands/builder/multiarch"
-
 class Mrsk::Commands::Builder::Multiarch::Remote < Mrsk::Commands::Builder::Multiarch
   def create
     combine \

--- a/lib/mrsk/commands/builder/native.rb
+++ b/lib/mrsk/commands/builder/native.rb
@@ -1,5 +1,3 @@
-require "mrsk/commands/builder/base"
-
 class Mrsk::Commands::Builder::Native < Mrsk::Commands::Builder::Base
   def create
     # No-op on native

--- a/lib/mrsk/commands/builder/native/remote.rb
+++ b/lib/mrsk/commands/builder/native/remote.rb
@@ -1,5 +1,3 @@
-require "mrsk/commands/builder/native"
-
 class Mrsk::Commands::Builder::Native::Remote < Mrsk::Commands::Builder::Native
   def create
     chain \

--- a/lib/mrsk/commands/prune.rb
+++ b/lib/mrsk/commands/prune.rb
@@ -1,4 +1,3 @@
-require "mrsk/commands/base"
 require "active_support/duration"
 require "active_support/core_ext/numeric/time"
 

--- a/lib/mrsk/commands/registry.rb
+++ b/lib/mrsk/commands/registry.rb
@@ -1,5 +1,3 @@
-require "mrsk/commands/base"
-
 class Mrsk::Commands::Registry < Mrsk::Commands::Base
   delegate :registry, to: :config
 

--- a/lib/mrsk/commands/traefik.rb
+++ b/lib/mrsk/commands/traefik.rb
@@ -1,5 +1,3 @@
-require "mrsk/commands/base"
-
 class Mrsk::Commands::Traefik < Mrsk::Commands::Base
   def run
     docker :run, "--name traefik",

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -3,7 +3,6 @@ require "active_support/core_ext/string/inquiry"
 require "active_support/core_ext/module/delegation"
 require "pathname"
 require "erb"
-require "mrsk/utils"
 
 class Mrsk::Configuration
   delegate :service, :image, :servers, :env, :labels, :registry, :builder, to: :raw_config, allow_nil: true
@@ -171,6 +170,3 @@ class Mrsk::Configuration
       raw_config.servers.is_a?(Array) ? [ "web" ] : raw_config.servers.keys.sort
     end
 end
-
-require "mrsk/configuration/role"
-require "mrsk/configuration/accessory"

--- a/mrsk.gemspec
+++ b/mrsk.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sshkit", "~> 1.21"
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "dotenv", "~> 2.8"
+  spec.add_dependency "zeitwerk", "~> 2.5"
 end

--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -1,6 +1,5 @@
 require "test_helper"
 require "active_support/testing/stream"
-require "mrsk/cli"
 
 class CliTestCase < ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "mrsk/commander"
 
 class CommanderTest < ActiveSupport::TestCase
   setup do

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -1,10 +1,8 @@
 require "test_helper"
-require "mrsk/configuration"
-require "mrsk/commands/accessory"
 
 class CommandsAccessoryTest < ActiveSupport::TestCase
   setup do
-    @config = { 
+    @config = {
       service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" },
       servers: [ "1.1.1.1" ],
       accessories: {

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -1,6 +1,4 @@
 require "test_helper"
-require "mrsk/configuration"
-require "mrsk/commands/app"
 
 class CommandsAppTest < ActiveSupport::TestCase
   setup do

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -1,6 +1,4 @@
 require "test_helper"
-require "mrsk/configuration"
-require "mrsk/commands/builder"
 
 class CommandsBuilderTest < ActiveSupport::TestCase
   setup do

--- a/test/commands/registry_test.rb
+++ b/test/commands/registry_test.rb
@@ -1,10 +1,8 @@
 require "test_helper"
-require "mrsk/configuration"
-require "mrsk/commands/registry"
 
 class CommandsRegistryTest < ActiveSupport::TestCase
   setup do
-    @config = { service: "app", 
+    @config = { service: "app",
       image: "dhh/app",
       registry: { "username" => "dhh",
         "password" => "secret",

--- a/test/commands/traefik_test.rb
+++ b/test/commands/traefik_test.rb
@@ -1,6 +1,4 @@
 require "test_helper"
-require "mrsk/configuration"
-require "mrsk/commands/traefik"
 
 class CommandsTraefikTest < ActiveSupport::TestCase
   setup do

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "mrsk/configuration"
 
 class ConfigurationAccessoryTest < ActiveSupport::TestCase
   setup do
@@ -66,7 +65,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
   test "missing host" do
     @deploy[:accessories]["mysql"]["host"] = nil
     @config = Mrsk::Configuration.new(@deploy)
-    
+
     assert_raises(ArgumentError) do
       @config.accessory(:mysql).host
     end

--- a/test/configuration/role_test.rb
+++ b/test/configuration/role_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "mrsk/configuration"
 
 class ConfigurationRoleTest < ActiveSupport::TestCase
   setup do
@@ -63,7 +62,7 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
   end
 
   test "default traefik label on non-web role" do
-    config = Mrsk::Configuration.new(@deploy_with_roles.tap { |c| 
+    config = Mrsk::Configuration.new(@deploy_with_roles.tap { |c|
       c[:servers]["beta"] = { "traefik" => "true", "hosts" => [ "1.1.1.5" ] }
     })
 
@@ -97,7 +96,7 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
 
     ENV["REDIS_PASSWORD"] = "secret456"
     ENV["DB_PASSWORD"] = "secret123"
-    
+
     assert_equal ["-e", "REDIS_PASSWORD=secret456", "-e", "DB_PASSWORD=secret123", "-e", "REDIS_URL=redis://a/b", "-e", "WEB_CONCURRENCY=4"], @config_with_roles.role(:workers).env_args
   ensure
     ENV["REDIS_PASSWORD"] = nil
@@ -116,7 +115,7 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
     }
 
     ENV["DB_PASSWORD"] = "secret123"
-    
+
     assert_equal ["-e", "DB_PASSWORD=secret123", "-e", "REDIS_URL=redis://a/b", "-e", "WEB_CONCURRENCY=4"], @config_with_roles.role(:workers).env_args
   ensure
     ENV["DB_PASSWORD"] = nil
@@ -133,7 +132,7 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
     }
 
     ENV["REDIS_PASSWORD"] = "secret456"
-    
+
     assert_equal ["-e", "REDIS_PASSWORD=secret456", "-e", "REDIS_URL=redis://a/b", "-e", "WEB_CONCURRENCY=4"], @config_with_roles.role(:workers).env_args
   ensure
     ENV["REDIS_PASSWORD"] = nil

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "mrsk/configuration"
 
 class ConfigurationTest < ActiveSupport::TestCase
   setup do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require "debug"
 require "mocha/minitest" # using #stubs that can alter returns
 require "minitest/autorun" # using #stub that take args
 require "sshkit"
+require "mrsk"
 
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["VERBOSE"]
 


### PR DESCRIPTION
This patch lets MRSK load with Zeitwerk:

* The project was in excellent shape re conventions.
* There are about 60 `require` calls deleted in code and tests.
* The loader eager loads the project because Thor commands need to be in memory. I inspected `$LOADED_FEATURES` in `main` and the existing `require` calls were basically doing the same thing in cascade anyway.
* `bin/mrsk` now loads the entrypoint instead of `mrsk/cli` to have the loader in place. With that, the subsequent reference to `Mrsk::Cli::Main` just works. Note that `lib/mrsk/cli.rb` was loading the entrypoint, so in a sense this setup simplifies and orders bootstrapping in a natural way.
* Similarly, `test/test_helper.rb` loads the entrypoint as well.
* The file `lib/mrsk/sshkit_with_ext.rb` is special and this is fine, we just tell the loader to ignore it. This extension is loaded with an ordinary `require` where is needed (same original spot, not edited).
* There's some extra diff lines due to whitespace cleanup (automatic in my editor).

References #34.